### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a simple Express server with a search endpoint for tasks.

### What changed?

Created a new `server.js` file in the graphite-demo directory that:
- Sets up an Express server running on port 3000
- Includes a mock dataset of tasks with IDs and descriptions
- Implements a `/search` endpoint that filters tasks based on a query parameter

### How to test?

1. Start the server: `node graphite-demo/server.js`
2. Test the search endpoint with different queries:
   - `curl http://localhost:3000/search` (returns all tasks)
   - `curl http://localhost:3000/search?query=report` (returns tasks containing "report")
   - `curl http://localhost:3000/search?query=team` (returns tasks containing "team")

### Why make this change?

This provides a basic backend API for task searching functionality, which can be integrated with a frontend application. The implementation allows for case-insensitive partial matching of task descriptions.