### PR TITLE
Add frontend for search

### DIFF
--- a/graphite-demo/frontend.jsx
+++ b/graphite-demo/frontend.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+const TaskSearch = () => {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/search?query=${encodeURIComponent(searchQuery)}`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(data => {
+        setTasks(data);
+        setLoading(false);
+      })
+      .catch(error => {
+        setError(error.message);
+        setLoading(false);
+      });
+  }, [searchQuery]); // Depend on searchQuery
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <div>
+      <h2>Task Search</h2>
+      <input
+        type="text"
+        placeholder="Search tasks..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id}>
+            <p>{task.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TaskSearch;


### PR DESCRIPTION
### TL;DR

Added a new React component for task searching functionality.

### What changed?

Created a new `frontend.jsx` file in the graphite-demo directory that implements a `TaskSearch` React component. This component:
- Manages tasks, loading state, error state, and search query in its state
- Fetches tasks from a `/search` endpoint based on the user's search query
- Displays a loading indicator while fetching data
- Shows error messages if the fetch fails
- Renders a search input and a list of tasks with their descriptions

### How to test?

1. Import and render the `TaskSearch` component in your application
2. Ensure the `/search` endpoint is properly implemented on the backend
3. Enter different search queries in the input field and verify that:
   - The loading indicator appears during fetches
   - Tasks are displayed correctly after loading
   - Error messages appear when the API call fails

### Why make this change?

This component provides a user interface for searching tasks, allowing users to quickly find specific tasks by entering search terms. It improves the application's usability by providing real-time search functionality with appropriate loading and error states.